### PR TITLE
Fix for crash on diff-from-tree-tab on Atom ~1.17.0

### DIFF
--- a/lib/atom-meld.coffee
+++ b/lib/atom-meld.coffee
@@ -132,7 +132,7 @@ module.exports = Atommeld =
     treeViewObj = null
     if atom.packages.isPackageLoaded('tree-view') == true
       treeView = atom.packages.getLoadedPackage('tree-view')
-      treeView = require(treeView.mainModulePath)
+      treeView = require(treeView.mainModulePath).getTreeViewInstance()
       treeViewObj = treeView.serialize()
     if typeof treeViewObj != 'undefined' && treeViewObj != null
       if treeViewObj.selectedPath


### PR DESCRIPTION
Fixes behavior on the current 1.17.0 stable and 1.18.0 beta.
On 1.16.0 getTreeViewInstance() does not exist ...
It will throw an exception and advise upgrading Atom to current stable.